### PR TITLE
feat: Enable capability of find enums with spaces and new methods for easy interaction

### DIFF
--- a/src/plexosdb/enums.py
+++ b/src/plexosdb/enums.py
@@ -71,6 +71,7 @@ class ClassEnum(StrEnum):
     Production = "Production"
     Performance = "Performance"
     Variable = "Variable"
+    Constraint = "Constraint"
 
 
 plexos_class_mapping = {enum_member.name: enum_member.value for enum_member in ClassEnum}
@@ -84,8 +85,7 @@ class CollectionEnum(StrEnum):
     HeadStorage = "HeadStorage"
     TailStorage = "TailStorage"
     Nodes = "Nodes"
-    Battery = "Battery"
-    Storage = "Storage"
+    Storages = "Storages"
     Emissions = "Emissions"
     Reserves = "Reserves"
     Batteries = "Batteries"
@@ -98,10 +98,12 @@ class CollectionEnum(StrEnum):
     NodeTo = "NodeTo"
     Transformers = "Transformers"
     Interfaces = "Interfaces"
-    Scenarios = "Scenarios"
     Models = "Models"
     Scenario = "Scenario"
+    Scenarios = "Scenarios"
     Horizon = "Horizon"
+    Horizons = "Horizons"
+    Report = "Report"
     Reports = "Reports"
     PASA = "PASA"
     MTSchedule = "MTSchedule"
@@ -109,8 +111,11 @@ class CollectionEnum(StrEnum):
     Transmission = "Transmission"
     Production = "Production"
     Diagnostic = "Diagnostic"
+    Diagnostics = "Diagnostics"
     Performance = "Performance"
     DataFiles = "DataFiles"
+    Constraint = "Constraint"
+    Constraints = "Constraints"
 
 
 def str2enum(string, schema_enum=Schema) -> Schema | None:

--- a/src/plexosdb/schema.sql
+++ b/src/plexosdb/schema.sql
@@ -89,7 +89,7 @@ CREATE TABLE `t_custom_rule`
 CREATE TABLE `t_class`
 (
     `class_id` INT NOT NULL,
-    `name` VARCHAR(255) NULL,
+    `name` VARCHAR(255) NULL COLLATE NOSPACE,
     `class_group_id` INT NULL,
     `is_enabled` BIT NULL,
     `lang_id` INT NULL,
@@ -105,7 +105,7 @@ CREATE TABLE `t_collection`
     `collection_id` INT NOT NULL,
     `parent_class_id` INT NULL,
     `child_class_id` INT NULL,
-    `name` VARCHAR(255) NULL,
+    `name` VARCHAR(255) NULL COLLATE NOSPACE,
     `min_count` INT NULL,
     `max_count` INT NULL,
     `complement_name` VARCHAR(255) NULL,

--- a/src/plexosdb/utils.py
+++ b/src/plexosdb/utils.py
@@ -51,3 +51,12 @@ def validate_string(value: str) -> Any:
         logger.trace("Could not parse {}", value)
     finally:
         return value
+
+
+def no_space(a: str, b: str) -> int:
+    """Collate function for catching strings with spaces."""
+    if a.replace(" ", "") == b.replace(" ", ""):
+        return 0
+    if a.replace(" ", "") == b.replace(" ", ""):
+        return -1
+    return 1


### PR DESCRIPTION
This PR expand of the change that we made on using the `ClassEnum` and `CollectionEnum` name instead of having a fix `ID`. Now, we do searches using the name of the class only and in the instance that we do not have the name on the table, we perform a join operation to get it.

List of changes:
- Added new getter methods for `class_id` and to get max rank for category,
- Fixed `_get_id` with a more robust approach to add joins and where clauses,
- Propagated entries where we need `valid_properties`
- Added automatic creation of the Coalesce for the dynamic queries,
- Removed the MASTER_XML to avoid conflicts
- Updated enums to match correct name for collections