### PR TITLE
Feat/cache queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "plexosdb"
-version = "0.0.6"
+version = "0.0.7"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
 keywords = []

--- a/src/plexosdb/schema.sql
+++ b/src/plexosdb/schema.sql
@@ -231,7 +231,7 @@ CREATE TABLE `t_category`
 
 CREATE TABLE `t_object`
 (
-    `object_id` INTEGER,
+    `object_id` INTEGER UNIQUE,
     `class_id` INT NULL,
     `name` VARCHAR(512) NULL COLLATE NOCASE,
     `category_id` INT NULL,
@@ -241,6 +241,7 @@ CREATE TABLE `t_object`
     `X` INT NULL,
     `Y` INT NULL,
     `Z` INT NULL,
+    UNIQUE (`class_id`, `name`)
     CONSTRAINT PK_t_object
                PRIMARY KEY (`object_id`)
 );

--- a/src/plexosdb/sqlite.py
+++ b/src/plexosdb/sqlite.py
@@ -446,6 +446,11 @@ class PlexosSQLite:
         -----
         By default, we add all objects to the system membership.
 
+        Raises
+        ------
+        sqlite.IntegrityError
+            if an object is inserted without a unique name/class pair
+
         Returns
         -------
         int
@@ -461,17 +466,14 @@ class PlexosSQLite:
 
         params = (object_name, class_id, category_id, str(uuid.uuid4()), description)
         placeholders = ", ".join("?" * len(params))
-        try:
-            with self._conn as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    f"INSERT INTO {Schema.Objects.name}(name, class_id, category_id, GUID, description) "
-                    f"VALUES({placeholders})",
-                    params,
-                )
-                object_id = cursor.lastrowid
-        except sqlite3.IntegrityError as err:
-            raise ValueError(err)
+        with self._conn as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"INSERT INTO {Schema.Objects.name}(name, class_id, category_id, GUID, description) "
+                f"VALUES({placeholders})",
+                params,
+            )
+            object_id = cursor.lastrowid
 
         if object_id is None:
             raise TypeError("Could not fetch the last row of the insert. Check query format.")

--- a/src/plexosdb/sqlite.py
+++ b/src/plexosdb/sqlite.py
@@ -1081,8 +1081,6 @@ class PlexosSQLite:
             String to get passed to the database connector.
         params
             Tuple or dict for passing
-        fetchone
-            Return firstrow
 
         Note
         ----

--- a/src/plexosdb/sqlite.py
+++ b/src/plexosdb/sqlite.py
@@ -1102,8 +1102,6 @@ class PlexosSQLite:
             try:
                 with self._conn as conn:
                     conn.execute(ingestion_sql, record)
-            except sqlite3.IntegrityError as err:
-                raise ValueError(err)
             except sqlite3.Error as err:
                 raise err
 

--- a/src/plexosdb/sqlite.py
+++ b/src/plexosdb/sqlite.py
@@ -38,6 +38,7 @@ class PlexosSQLite:
         self._conn = sqlite3.connect(":memory:")
         self._sqlite_config()
         self._QUERY_CACHE: dict[int, int] = {}
+
         if create_collations:
             self._create_collations()
         self._create_table_schema()
@@ -757,7 +758,6 @@ class PlexosSQLite:
         parent_class_name: ClassEnum | None = None,
         child_class_name: ClassEnum | None = None,
         category_name: str | None = None,
-        use_cache: bool = True,
     ) -> int:
         """Return the ID for a given table and object name combination.
 
@@ -840,7 +840,7 @@ class PlexosSQLite:
             else f" WHERE {table_name}.name = :object_name"
         )
         query_key = self._query_hash(query, params)
-        if query_key in self._QUERY_CACHE and use_cache:
+        if query_key in self._QUERY_CACHE:
             return self._QUERY_CACHE[query_key]
 
         result = self.query(query, params)
@@ -1272,5 +1272,5 @@ class PlexosSQLite:
         return hash((query_string, params))
 
     def clear_id_cache(self):
-        """Clear the cache of id's returned by _get_id."""
+        """Clear the cache for the _get_id method."""
         self._QUERY_CACHE.clear()

--- a/tests/data/plexosdb.xml
+++ b/tests/data/plexosdb.xml
@@ -82,7 +82,7 @@
 	<t_object>
 		<object_id>3</object_id>
 		<class_id>2</class_id>
-		<name>SolarPV01</name>
+		<name>SolarPV02</name>
 		<category_id>97</category_id>
 		<GUID>40d15a07-8ccc-460e-919a-ec8e211899a8</GUID>
 	</t_object>

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -6,7 +6,6 @@ from plexosdb.sqlite import PlexosSQLite
 from sqlite3 import IntegrityError
 from collections.abc import Generator
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 DB_FILENAME = "plexosdb.xml"
 
@@ -17,10 +16,9 @@ def db_empty() -> "PlexosSQLite":
 
 
 @pytest.fixture
-def db(data_folder: Path) -> Generator[PlexosSQLite, None, None]:
-    tmp_dir = TemporaryDirectory()  # dir=data_folder.parent)
+def db(data_folder: Path, tmp_path: Path) -> Generator[PlexosSQLite, None, None]:
     xml_fname = data_folder / DB_FILENAME
-    xml_copy = Path(tmp_dir.name) / f"copy_{DB_FILENAME}"
+    xml_copy = tmp_path / f"copy_{DB_FILENAME}"
     shutil.copy(xml_fname, xml_copy)
     db = PlexosSQLite(xml_fname=str(xml_copy))
     yield db

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -159,19 +159,9 @@ def test_get_collection_id(db):
 
 @pytest.mark.get_functions
 def test_get_object_id(db):
-    db.clear_id_cache()
-    gen_01_name = "gen1"
-    gen_id = db.add_object(
-        gen_01_name, ClassEnum.Generator, CollectionEnum.Generators, description="Test Gen"
-    )
-    assert gen_id
-
-    gen_id_get = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
-    assert gen_id == gen_id_get
-
-    # Add generator with same name different category
     gen_01_name = "gen1"
     category_name = "PV Gens"
+
     gen_id = db.add_object(
         gen_01_name,
         ClassEnum.Generator,
@@ -179,8 +169,22 @@ def test_get_object_id(db):
         description="Test Gen",
         category_name=category_name,
     )
+    assert gen_id
+
+    gen_id_get = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
+    assert gen_id == gen_id_get
+
+    # Add generator with same name different category
     with pytest.raises(ValueError):
-        _ = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
+        gen_01_name = "gen1"
+        gen_id = db.add_object(
+            gen_01_name,
+            ClassEnum.Generator,
+            CollectionEnum.Generators,
+            description="Test Gen",
+        )
+    # for a given class, all names should be unique
+    _ = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
 
     max_rank = db.get_category_max_id(ClassEnum.Generator)
     assert max_rank == 2  # Data has ranks 0, 1. 2 is with the new category

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -156,6 +156,7 @@ def test_get_collection_id(db):
 
 @pytest.mark.get_functions
 def test_get_object_id(db):
+    db.clear_id_cache()
     gen_01_name = "gen1"
     gen_id = db.add_object(
         gen_01_name, ClassEnum.Generator, CollectionEnum.Generators, description="Test Gen"
@@ -189,6 +190,7 @@ def test_get_object_id(db):
 
 @pytest.mark.get_functions
 def test_get_memberships(db):
+    db.clear_id_cache()
     # Test Node
     node_name = "Node 1"
     node_id = db.add_object(node_name, ClassEnum.Node, CollectionEnum.Nodes, description="Test Node")

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -80,10 +80,6 @@ def test_check_id_exists(db):
     assert isinstance(system_check, bool)
     assert not system_check
 
-    # Check that returns ValueError if multiple object founds
-    with pytest.raises(ValueError):
-        _ = db.check_id_exists(Schema.Objects, "SolarPV01", class_name=ClassEnum.Generator)
-
 
 @pytest.mark.get_functions
 def test_get_id(db):

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -4,6 +4,8 @@ import xml.etree.ElementTree as ET  # noqa: N817
 from plexosdb.enums import ClassEnum, CollectionEnum, Schema
 from plexosdb.sqlite import PlexosSQLite
 from collections.abc import Generator
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 DB_FILENAME = "plexosdb.xml"
 
@@ -14,11 +16,12 @@ def db_empty() -> "PlexosSQLite":
 
 
 @pytest.fixture
-def db(data_folder) -> Generator[PlexosSQLite, None, None]:
-    xml_fname = data_folder.joinpath(DB_FILENAME)
-    xml_copy = data_folder.joinpath(f"copy_{DB_FILENAME}")
+def db(data_folder: Path) -> Generator[PlexosSQLite, None, None]:
+    tmp_dir = TemporaryDirectory()  # dir=data_folder.parent)
+    xml_fname = data_folder / DB_FILENAME
+    xml_copy = Path(tmp_dir.name) / f"copy_{DB_FILENAME}"
     shutil.copy(xml_fname, xml_copy)
-    db = PlexosSQLite(xml_fname=xml_copy)
+    db = PlexosSQLite(xml_fname=str(xml_copy))
     yield db
     xml_copy.unlink()
 

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -3,6 +3,7 @@ import shutil
 import xml.etree.ElementTree as ET  # noqa: N817
 from plexosdb.enums import ClassEnum, CollectionEnum, Schema
 from plexosdb.sqlite import PlexosSQLite
+from sqlite3 import IntegrityError
 from collections.abc import Generator
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -178,7 +179,7 @@ def test_get_object_id(db):
     assert gen_id == gen_id_get
 
     # Add generator with same name and no category
-    with pytest.raises(ValueError):
+    with pytest.raises(IntegrityError):
         gen_id = db.add_object(
             gen_01_name,
             ClassEnum.Generator,

--- a/tests/test_plexosdb_sqlite.py
+++ b/tests/test_plexosdb_sqlite.py
@@ -174,17 +174,14 @@ def test_get_object_id(db):
     gen_id_get = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
     assert gen_id == gen_id_get
 
-    # Add generator with same name different category
+    # Add generator with same name and no category
     with pytest.raises(ValueError):
-        gen_01_name = "gen1"
         gen_id = db.add_object(
             gen_01_name,
             ClassEnum.Generator,
             CollectionEnum.Generators,
             description="Test Gen",
         )
-    # for a given class, all names should be unique
-    _ = db.get_object_id(gen_01_name, class_name=ClassEnum.Generator)
 
     max_rank = db.get_category_max_id(ClassEnum.Generator)
     assert max_rank == 2  # Data has ranks 0, 1. 2 is with the new category


### PR DESCRIPTION
Cache results from _get_id
In the run of:
`r2x -i temp_data/oct1024_Con_NG  --input-model=reeds-US --output-model=plexos --weather-year=2012 -o .out/$CASETS --year 2035 --plugins pcm_defaults emission_cap break_gens imports --debug --upgrade --flags daily-budgets=true`

In this case:
_get_id is called 434408 times
there are only 5397 unique calls of _get_id

Caching _get_id results leads to the performance gains:
plexos_exporter: 47.3s -> 19.7s
_get_id cumulative: 28.8s -> 1.7s
