### PR TITLE
feat: Adding capability to rename objects

### DIFF
--- a/docs/source/howtos/index.md
+++ b/docs/source/howtos/index.md
@@ -19,4 +19,5 @@ import_export
 manage_relationships
 copy_objects
 bulk_operations
+remove_non_ascii
 ```

--- a/docs/source/howtos/remove_non_ascii.md
+++ b/docs/source/howtos/remove_non_ascii.md
@@ -1,0 +1,22 @@
+# Removing non-ASCII text from names
+
+This in an example function that removes all non-ASCII characters.
+
+```python
+import unicodedata
+
+def clean_international_text(text: str) -> str:
+    normalized = unicodedata.normalize('NFKD', text)
+    ascii_text = normalized.encode('ASCII', 'ignore').decode('ASCII')
+    return ascii_text
+
+from plexosdb import PlexosDB
+from plexosdb.enums import ClassEnum, CollectionEnum
+db = PlexosDB()
+db.create_schema()
+
+original_name="Pälli")
+db.add_object(ClassEnum.Generator, original_name)
+new_name = clean_international_text(original_name)
+assert db.update_object(ClassEnum.Generator, "Pälli", new_name=new_name)
+```

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -3187,7 +3187,6 @@ class PlexosDB:
         self,
         class_enum: ClassEnum,
         object_name: str,
-        /,
         *,
         new_name: str,  # Required parameter now
         new_category: str | None = None,
@@ -3217,6 +3216,31 @@ class PlexosDB:
         ------
         AssertionError
             If the query fails
+
+        See Also
+        --------
+        get_object_id : Get the ID for an object
+        get_category_id : Get the ID for a category
+        add_object : Add a new object to the database
+
+        Examples
+        --------
+        >>> db = PlexosDB()
+        >>> db.create_schema()
+        >>> db.add_object(ClassEnum.Generator, "ThermalGen1", category="Thermal")
+        >>> db.add_object(ClassEnum.Generator, "SolarGen1", category="Solar")
+        >>> # Update just the name
+        >>> db.update_object(ClassEnum.Generator, "ThermalGen1", new_name="SolarGen")
+        True
+        >>> # Update name, category, and description
+        >>> db.update_object(
+        ...     ClassEnum.Generator,
+        ...     "SolarGen", 
+        ...     new_name="SolarGen2",
+        ...     new_category="Solar",
+        ...     new_description="Updated from thermal to solar generator"
+        ... )
+        True
         """
         object_id = self.get_object_id(class_enum, object_name)
 

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -3235,10 +3235,10 @@ class PlexosDB:
         >>> # Update name, category, and description
         >>> db.update_object(
         ...     ClassEnum.Generator,
-        ...     "SolarGen", 
+        ...     "SolarGen",
         ...     new_name="SolarGen2",
         ...     new_category="Solar",
-        ...     new_description="Updated from thermal to solar generator"
+        ...     new_description="Updated from thermal to solar generator",
         ... )
         True
         """

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -3185,16 +3185,59 @@ class PlexosDB:
 
     def update_object(
         self,
+        class_enum: ClassEnum,
         object_name: str,
         /,
         *,
-        class_enum: ClassEnum,
-        new_name: str | None = None,
+        new_name: str,  # Required parameter now
         new_category: str | None = None,
         new_description: str | None = None,
-    ) -> None:
-        """Update an object's attributes."""
-        raise NotImplementedError
+    ) -> bool:
+        """Update an object's attributes.
+
+        Parameters
+        ----------
+        class_enum : ClassEnum
+            Class enumeration of the object
+        object_name : str
+            Current name of the object to update
+        new_name : str
+            New name for the object
+        new_category : str | None, optional
+            New category for the object, by default None
+        new_description : str | None, optional
+            New description for the object, by default None
+
+        Returns
+        -------
+        bool
+            True if the update was successful
+
+        Raises
+        ------
+        AssertionError
+            If the query fails
+        """
+        object_id = self.get_object_id(class_enum, object_name)
+
+        set_clauses = ["name = ?"]
+        params: list[Any] = [new_name]
+
+        if new_category is not None:
+            category_id = self.get_category_id(class_enum, new_category)
+            set_clauses.append("category_id = ?")
+            params.append(category_id)
+
+        if new_description is not None:
+            set_clauses.append("description = ?")
+            params.append(new_description)
+
+        query = f"UPDATE {Schema.Objects.name} SET {', '.join(set_clauses)} WHERE object_id = ?"
+        params.append(object_id)
+
+        result = self._db.execute(query, tuple(params))
+        assert result
+        return True
 
     def update_properties(self, updates: list[dict]) -> None:
         """Update multiple properties in a single transaction."""

--- a/tests/test_plexosdb.py
+++ b/tests/test_plexosdb.py
@@ -162,6 +162,53 @@ def test_object_operations(db_instance_with_schema):
     assert len(db.list_objects_by_class(ClassEnum.Generator)) == 3
 
 
+@pytest.mark.object_operations
+def test_update_object(db_instance_with_schema):
+    db = db_instance_with_schema
+
+    # Add categories and object with property
+    db.add_category(ClassEnum.Generator, "Thermal")
+    db.add_category(ClassEnum.Generator, "Solar")
+    object_id = db.add_object(ClassEnum.Generator, "TestGen", category="Thermal")
+
+    # Update name only
+    assert db.update_object(ClassEnum.Generator, "TestGen", new_name="UpdatedGen") is True
+    assert db.get_object_id(ClassEnum.Generator, "UpdatedGen") == object_id
+    assert not db.check_object_exists(ClassEnum.Generator, "TestGen")
+
+    # Update all fields and verify them
+    assert (
+        db.update_object(
+            ClassEnum.Generator,
+            "UpdatedGen",
+            new_name="FinalGen",
+            new_category="Solar",
+            new_description="Updated generator",
+        )
+        is True
+    )
+
+    result = db.query(
+        """
+        SELECT o.name, c.name as category, o.description
+        FROM t_object o
+        LEFT JOIN t_category c ON o.category_id = c.category_id
+        WHERE o.object_id = ?
+    """,
+        (object_id,),
+    )
+    assert result
+    assert result[0][0] == "FinalGen"
+    assert result[0][1] == "Solar"
+    assert result[0][2] == "Updated generator"
+
+    with pytest.raises(AssertionError):
+        db.update_object(ClassEnum.Generator, "NonexistentGen", new_name="NewName")
+
+    with pytest.raises(AssertionError):
+        db.update_object(ClassEnum.Generator, "FinalGen", new_name="Test", new_category="BadCategory")
+
+
 @pytest.mark.adders
 def test_add_property_to_object(db_instance_with_schema):
     db = db_instance_with_schema


### PR DESCRIPTION
This PR implements `update_object` for the DB that allows to modify the name, category and description for an existing object.