### PR TITLE
feat: Adding capability to remove object and cascade

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,7 +1,9 @@
 (api)=
-# API
+# API Reference
 
-PlexosDB offers a comprehensive Python API for working with PLEXOS energy market simulation models.
+This section provides comprehensive reference documentation for all PlexosDB classes, methods, and modules. Use this section when you need detailed information about specific functions, their parameters, return values, and behavior.
+
+## Core Components
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/source/howtos/delete_objects.md
+++ b/docs/source/howtos/delete_objects.md
@@ -1,6 +1,4 @@
-# Deleting Objects from the Database
-
-## Basic Object Creation
+# Deleting Objects and Properties from the Database
 
 ```python
 from plexosdb import PlexosDB
@@ -10,7 +8,7 @@ from plexosdb.enums import ClassEnum
 db = PlexosDB()
 db.create_schema()
 
-# Add a test generator object
+# Add a simple test generator object
 db.add_object(
     ClassEnum.Generator,
     name="TestGenerator",

--- a/docs/source/howtos/delete_objects.md
+++ b/docs/source/howtos/delete_objects.md
@@ -1,0 +1,23 @@
+# Deleting Objects from the Database
+
+## Basic Object Creation
+
+```python
+from plexosdb import PlexosDB
+from plexosdb.enums import ClassEnum
+
+# Initialize database
+db = PlexosDB()
+db.create_schema()
+
+# Add a test generator object
+db.add_object(
+    ClassEnum.Generator,
+    name="TestGenerator",
+    description="Example generator",
+    category="Thermal"
+)
+
+# Delete object
+db.delete_object(object_class, name=object_name)
+```

--- a/docs/source/howtos/delete_objects.md
+++ b/docs/source/howtos/delete_objects.md
@@ -1,5 +1,11 @@
 # Deleting Objects and Properties from the Database
 
+This guide demonstrates how to delete objects and properties from the PlexosDB database.
+
+## Deleting Objects
+
+When you delete an object, all its associated data (properties, memberships, etc.) are automatically removed due to foreign key constraints with cascade deletion.
+
 ```python
 from plexosdb import PlexosDB
 from plexosdb.enums import ClassEnum
@@ -16,6 +22,121 @@ db.add_object(
     category="Thermal"
 )
 
-# Delete object
-db.delete_object(object_class, name=object_name)
+# Delete the entire object (removes all properties and memberships)
+db.delete_object(ClassEnum.Generator, name="TestGenerator")
+```
+
+## Deleting Properties
+
+You can delete specific properties from objects without removing the object itself. This provides fine-grained control over data management.
+
+### Basic Property Deletion
+
+```python
+from plexosdb import PlexosDB
+from plexosdb.enums import ClassEnum
+
+# Initialize database from XML or create new
+db = PlexosDB.from_xml("model.xml")
+
+# Add a generator with properties
+db.add_object(ClassEnum.Generator, "PowerPlant1")
+db.add_property(ClassEnum.Generator, "PowerPlant1", "Max Capacity", 500.0)
+db.add_property(ClassEnum.Generator, "PowerPlant1", "Min Stable Level", 100.0)
+
+# Delete a specific property
+db.delete_property(ClassEnum.Generator, "PowerPlant1", property_name="Min Stable Level")
+
+# The object still exists, but only with the "Max Capacity" property
+```
+
+### Scenario-Specific Property Deletion
+
+When properties have scenario-specific values, you can delete only the property data associated with a particular scenario:
+
+```python
+# Add properties with different scenarios
+db.add_property(ClassEnum.Generator, "PowerPlant1", "Max Capacity", 500.0)  # Base case
+db.add_property(ClassEnum.Generator, "PowerPlant1", "Max Capacity", 600.0, scenario="High Demand")
+db.add_property(ClassEnum.Generator, "PowerPlant1", "Max Capacity", 400.0, scenario="Low Demand")
+
+# Delete only the "High Demand" scenario property
+db.delete_property(
+    ClassEnum.Generator,
+    "PowerPlant1",
+    property_name="Max Capacity",
+    scenario="High Demand"
+)
+
+# The base case and "Low Demand" scenario properties remain
+```
+
+### Advanced Property Deletion
+
+You can specify custom collections and parent classes when deleting properties:
+
+```python
+from plexosdb.enums import CollectionEnum
+
+# Delete property with specific collection
+db.delete_property(
+    ClassEnum.Generator,
+    "PowerPlant1",
+    property_name="Heat Rate",
+    collection=CollectionEnum.GeneratorProperties,
+    parent_class=ClassEnum.System
+)
+```
+
+## Important Notes
+
+### Cascade Deletion Behavior
+
+- **Object deletion**: Removes the object and ALL associated data (properties, memberships, text data, etc.)
+- **Property deletion**: Removes only the specified property data, including associated text, tags, and date ranges
+- **Scenario-specific deletion**: Removes only property data tagged with the specified scenario
+
+### Error Handling
+
+The deletion methods will raise appropriate exceptions if:
+
+- The object doesn't exist (`NotFoundError`)
+- The property name is invalid for the collection (`NameError`)
+- The property doesn't exist for the object (`NotFoundError`)
+- The specified scenario doesn't exist (`NotFoundError`)
+
+```python
+from plexosdb.exceptions import NotFoundError, NameError
+
+try:
+    db.delete_property(ClassEnum.Generator, "NonexistentGen", property_name="Max Capacity")
+except NotFoundError as e:
+    print(f"Error: {e}")
+
+try:
+    db.delete_property(ClassEnum.Generator, "PowerPlant1", property_name="Invalid Property")
+except NameError as e:
+    print(f"Error: {e}")
+```
+
+## Best Practices
+
+1. **Backup data**: Always backup your database before performing bulk deletions
+2. **Verify existence**: Check that objects and properties exist before attempting deletion
+3. **Use transactions**: For complex operations, wrap deletions in database transactions
+4. **Scenario management**: Be specific about scenarios when deleting scenario-based properties
+
+```python
+# Example of safe deletion with verification
+if db.check_object_exists(ClassEnum.Generator, "PowerPlant1"):
+    properties = db.get_object_properties(ClassEnum.Generator, "PowerPlant1")
+    property_names = [p["property"] for p in properties]
+
+    if "Max Capacity" in property_names:
+        db.delete_property(ClassEnum.Generator, "PowerPlant1", property_name="Max Capacity")
+        print("Property deleted successfully")
+    else:
+        print("Property not found")
+else:
+    print("Object not found")
 ```

--- a/docs/source/howtos/index.md
+++ b/docs/source/howtos/index.md
@@ -13,6 +13,7 @@ This section contains practical guides for common tasks with PlexosDB.
 create_db
 add_objects
 add_properties
+delete_objects
 query_database
 work_with_scenarios
 import_export

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,48 +1,72 @@
-# plexosdb Documentation
+# PlexosDB Documentation
 
-plexosdb is a Python library for working with PLEXOS energy market simulation models.
+PlexosDB is a Python library for working with PLEXOS energy market simulation models.
 
 ```{toctree}
 :maxdepth: 2
 :hidden:
 
 installation
+tutorial
 howtos/index
 api/index
 CHANGELOG
 ```
 
-## Features
+## About PlexosDB
 
-- Complete API for creating and manipulating energy system models with support
-for generators, regions, lines, and other PLEXOS components
-- Optimized SQLite backend with transaction support, bulk operations, and
-memory-efficient iterators for large datasets
-- Seamless conversion between PLEXOS XML format and database representation for
-compatibility with PLEXOS
-- Built-in support for creating multiple scenarios and analyzing differences
-between model configurations
+PlexosDB provides a Python interface for working with PLEXOS energy market simulation models. The library converts PLEXOS XML files into SQLite databases and offers a comprehensive API for creating, querying, and manipulating energy system models.
 
-## Quick Start
+### Key Features
 
-```python
-from plexosdb import PlexosDB
-from plexosdb.enums import ClassEnum
+PlexosDB offers the following capabilities:
 
-# Create a database from an XML file
-db = PlexosDB.from_xml("/path/to/plexos_model.xml")
+- Complete support for PLEXOS model components including generators, regions, lines, and transmission networks
+- Optimized SQLite backend with transaction support and bulk operations for handling large datasets efficiently
+- Seamless bidirectional conversion between PLEXOS XML format and database representation
+- Scenario management system for creating and comparing different model configurations
+- Memory-efficient iterators and chunked processing for working with large models
 
-# List all generators in the model
-generators = db.list_objects_by_class(ClassEnum.Generator)
-print(f"Found {len(generators)} generators")
+## Getting Started
 
-# Get properties for a specific generator
-gen_props = db.get_object_properties(ClassEnum.Generator, generators[0])
-for prop in gen_props:
-    print(f"{prop['property']}: {prop['value']} {prop['unit'] or ''}")
+To begin using PlexosDB, start with the installation guide and then follow the step-by-step tutorial:
+
+```{toctree}
+:maxdepth: 1
+
+installation
+tutorial
 ```
 
+## How-to Guides
 
+Task-oriented guides for specific workflows:
+
+```{toctree}
+:maxdepth: 1
+
+howtos/index
+```
+
+## Reference
+
+Complete API documentation:
+
+```{toctree}
+:maxdepth: 2
+
+api/index
+```
+
+## Release Notes
+
+Track changes and updates:
+
+```{toctree}
+:maxdepth: 1
+
+CHANGELOG
+```
 
 ## Indices and Tables
 

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -1,0 +1,188 @@
+# Tutorial
+
+This tutorial provides a step-by-step introduction to PlexosDB, guiding you through the essential concepts and operations for working with PLEXOS energy market simulation models.
+
+## Prerequisites
+
+Before starting this tutorial, ensure you have:
+
+- Python 3.7 or higher installed
+- PlexosDB installed (see [Installation](installation.md))
+- Basic understanding of energy market modeling concepts
+
+## Learning Objectives
+
+By the end of this tutorial, you will be able to:
+
+- Create and initialize a PlexosDB database
+- Import data from PLEXOS XML files
+- Add objects and properties to your model
+- Query the database for information
+- Work with scenarios and model configurations
+
+## Creating Your First Database
+
+Let's start by creating a new PlexosDB database:
+
+```python
+from plexosdb import PlexosDB
+
+# Create a new in-memory database
+db = PlexosDB()
+
+# Initialize the database schema
+db.create_schema()
+```
+
+This creates an empty database with the PLEXOS schema structure ready for data.
+
+## Working with Objects
+
+Objects represent entities in your energy model such as generators, nodes, and regions.
+
+### Adding Objects
+
+```python
+from plexosdb.enums import ClassEnum
+
+# Add a generator to the database
+db.add_object(ClassEnum.Generator, "Generator1")
+
+# Add a node with additional details
+db.add_object(ClassEnum.Node, "Node1", description="Main transmission node")
+
+# Verify objects were added
+generators = db.list_objects_by_class(ClassEnum.Generator)
+print(f"Generators: {generators}")
+```
+
+### Adding Properties
+
+Properties define characteristics of objects like capacity, cost, or operational parameters:
+
+```python
+# Add capacity property to the generator
+db.add_property(
+    ClassEnum.Generator,
+    "Generator1",
+    "Max Capacity",
+    500.0  # MW
+)
+
+# Add multiple properties
+db.add_property(ClassEnum.Generator, "Generator1", "Min Stable Level", 100.0)
+db.add_property(ClassEnum.Generator, "Generator1", "Heat Rate", 9500.0)
+```
+
+### Querying Properties
+
+Retrieve property information for specific objects:
+
+```python
+# Get all properties for Generator1
+properties = db.get_object_properties(ClassEnum.Generator, "Generator1")
+
+for prop in properties:
+    print(f"{prop['property']}: {prop['value']} {prop['unit'] or ''}")
+```
+
+## Working with XML Files
+
+PlexosDB can import existing PLEXOS XML files and export databases back to XML format.
+
+### Importing from XML
+
+```python
+# Create database from existing XML file
+db = PlexosDB.from_xml("/path/to/your/plexos_model.xml")
+
+# List all generators in the imported model
+generators = db.list_objects_by_class(ClassEnum.Generator)
+print(f"Found {len(generators)} generators in the model")
+```
+
+### Exporting to XML
+
+```python
+# Export your database to XML format
+db.to_xml("/path/to/output_model.xml")
+```
+
+## Working with Scenarios
+
+Scenarios allow you to model different operational conditions or future projections:
+
+```python
+# Add a scenario
+scenario_id = db.add_scenario("High Demand")
+
+# Add property with scenario context
+db.add_property(
+    ClassEnum.Generator,
+    "Generator1",
+    "Max Capacity",
+    750.0,  # Increased capacity for high demand scenario
+    scenario="High Demand"
+)
+
+# List all scenarios
+scenarios = db.list_scenarios()
+print(f"Available scenarios: {scenarios}")
+```
+
+## Working with Collections and Memberships
+
+Collections define relationships between objects in your model:
+
+```python
+from plexosdb.enums import CollectionEnum
+
+# Add a region
+db.add_object(ClassEnum.Region, "RegionA")
+
+# Create membership: Generator1 belongs to RegionA
+db.add_membership(
+    parent_class_enum=ClassEnum.Region,
+    child_class_enum=ClassEnum.Generator,
+    parent_object_name="RegionA",
+    child_object_name="Generator1",
+    collection_enum=CollectionEnum.Generators
+)
+
+# Query memberships
+memberships = db.list_object_memberships(ClassEnum.Generator, "Generator1")
+for member in memberships:
+    print(f"Generator1 belongs to {member['parent_name']} ({member['parent_class_name']})")
+```
+
+## Bulk Operations
+
+For large models, PlexosDB provides efficient bulk operations:
+
+```python
+# Add multiple objects at once
+generator_names = ["Gen1", "Gen2", "Gen3", "Gen4", "Gen5"]
+db.add_objects(*generator_names, class_enum=ClassEnum.Generator)
+
+# Bulk property addition using records
+property_records = [
+    {"name": "Gen1", "Max Capacity": 100.0, "Heat Rate": 9000.0},
+    {"name": "Gen2", "Max Capacity": 150.0, "Heat Rate": 9200.0},
+    {"name": "Gen3", "Max Capacity": 200.0, "Heat Rate": 8800.0},
+]
+
+db.add_properties_from_records(
+    property_records,
+    object_class=ClassEnum.Generator,
+    collection=CollectionEnum.Generators,
+    scenario="Base Case"
+)
+```
+
+## Next Steps
+
+Now that you have completed the tutorial, you can:
+
+1. Explore the [How-to Guides](howtos/index.md) for specific tasks
+2. Consult the [API Reference](api/index.md) for detailed method documentation
+3. Review examples in the source code test files

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -17,6 +17,7 @@ from .enums import ClassEnum, CollectionEnum, Schema, get_default_collection, st
 from .exceptions import (
     NameError,
     NoPropertiesError,
+    NotFoundError,
 )
 from .utils import create_membership_record, no_space, normalize_names, prepare_sql_data_params
 from .xml_handler import XMLHandler
@@ -859,9 +860,9 @@ class PlexosDB:
         """
         # Ensure object exist
         if not self.check_object_exists(object_class_enum, object_name):
-            msg = f"Object = `{name}` does not exist on the system. "
+            msg = f"Object = `{object_name}` does not exist on the system. "
             f"Check available objects for class `{object_class_enum}` using `list_objects_by_class`"
-            raise NameError(msg)
+            raise NotFoundError(msg)
         _ = self.get_object_id(object_class_enum, object_name)
 
         if not collection_enum:
@@ -1390,12 +1391,12 @@ class PlexosDB:
         # If we do not find a membership, we just look for the system membership
         if not membership_mapping:
             membership_mapping = {}
-            system_membership_id = self.get_object_memberships(
-                original_object_name, class_enum=object_class, include_system_membership=True
-            )[0]["membership_id"]
-            new_membership_id = self.get_object_memberships(
-                new_object_name, class_enum=object_class, include_system_membership=True
-            )[0]["membership_id"]
+            system_membership_id = self.list_object_memberships(object_class, original_object_name)[0][
+                "membership_id"
+            ]
+            new_membership_id = self.list_object_memberships(object_class, new_object_name)[0][
+                "membership_id"
+            ]
             membership_mapping[system_membership_id] = new_membership_id
 
         data_ids = self.get_object_data_ids(object_class, name=original_object_name)
@@ -1410,11 +1411,13 @@ class PlexosDB:
     def copy_object_memberships(self, object_class, original_name: str, new_name: str) -> dict[int, int]:
         """Copy all existing memberships of old object to the new object."""
         membership_mapping: dict[int, int] = {}
-        all_memberships = self.get_object_memberships(original_name, class_enum=object_class)
+        all_memberships = self.list_object_memberships(
+            object_class, original_name, exclude_system_membership=True
+        )
         for membership in all_memberships:
             membership_mapping = {}
-            parent_name = membership["parent"]
-            child_name = membership["child"]
+            parent_name = membership["parent_name"]
+            child_name = membership["child_name"]
             parent_class = ClassEnum[membership["parent_class_name"]]
             child_class = ClassEnum[membership["child_class_name"]]
             collection = CollectionEnum[membership["collection_name"]]
@@ -1609,9 +1612,18 @@ class PlexosDB:
         """Delete metadata from an entity."""
         raise NotImplementedError
 
-    def delete_object(self, object_name: str, /, *, class_enum: ClassEnum, cascade: bool = True) -> None:
-        """Delete an object from the database."""
-        raise NotImplementedError
+    def delete_object(self, class_enum: ClassEnum, /, *, name: str) -> None:
+        """Delete an object and its memberhips from the database.
+
+        Default behaviour is to remove all the references of the object including memberships and data.
+        """
+        object_id = self.get_object_id(class_enum, name=name)
+        delete_query = "DELETE FROM t_object WHERE object_id = ?"
+
+        # Handle delete in transaction in case an error happens.
+        with self._db.transaction():
+            self._db.execute(delete_query, (object_id,))
+        return
 
     def delete_property(
         self,
@@ -1757,7 +1769,9 @@ class PlexosDB:
         AND t_class.name = ?
         """
         result = self._db.fetchone(query, (name, class_enum))
-        assert result
+        if not result:
+            msg = f"Category = `{name} not found on the database."
+            raise NotFoundError(msg)
         return result[0]
 
     def get_category_max_id(self, class_enum: ClassEnum) -> int:
@@ -1972,36 +1986,34 @@ class PlexosDB:
         assert result
         return result[0]
 
-    def get_object_memberships(
+    def list_object_memberships(
         self,
-        *object_names: Iterable[str] | str,
         class_enum: ClassEnum,
-        parent_class_enum: ClassEnum | None = None,
+        /,
+        name: str,
         category: str | None = None,
-        collection_enum: CollectionEnum | None = None,
-        include_system_membership: bool = False,
+        collection: CollectionEnum | None = None,
+        exclude_system_membership: bool = False,
     ) -> list[dict[str, Any]]:
-        """Retrieve all memberships for the given object(s).
+        """Retrieve all memberships for a given object.
+
+        By default it does not return the system membership.
 
         Parameters
         ----------
-        object_names : str or list[str]
-            Name or list of names of the objects to get their memberships.
-            You can pass multiple string arguments or a single list of strings.
         class_enum : ClassEnum
-            Class of the objects.
-        parent_class_enum : ClassEnum | None, optional
-            Class of the parent object. Defaults to object_class if not provided.
+            Class of the object
+        name : str
+            Name of the object to get its memberships.
         collection : CollectionEnum | None, optional
             Collection to filter memberships.
-        include_system_membership : bool, optional
-            If False (default), exclude system memberships (where parent_class is System).
-            If True, include them.
+        exclude_system_membership : bool, optional
+            If True, exclude system memberships.
 
         Returns
         -------
-        list[tuple]
-            A list of tuples representing memberships. Each tuple is structured as:
+        list[dict]
+            A list of dicts representing memberships. Each tuple is structured as:
             (parent_class_id, child_class_id, parent_object_name, child_object_name, collection_id,
             return self.query(query_string=query_string, params=params)
             parent_class_name, collection_name).
@@ -2011,15 +2023,12 @@ class PlexosDB:
         KeyError
             If any of the object_names do not exist.
         """
-        object_ids = tuple(self.get_objects_id(*object_names, class_enum=class_enum))
+        object_id = self.get_object_id(class_enum, name=name)
         query_string = """
         SELECT
             mem.membership_id,
-            mem.parent_class_id,
-            mem.child_class_id,
-            parent_object.name AS parent,
-            child_object.name AS child,
-            mem.collection_id,
+            parent_object.name AS parent_name,
+            child_object.name AS child_name,
             parent_class.name AS parent_class_name,
             child_class.name AS child_class_name,
             collections.name AS collection_name
@@ -2036,27 +2045,27 @@ class PlexosDB:
         LEFT JOIN
             t_collection AS collections ON mem.collection_id = collections.collection_id
         """
-        conditions = []
-        if not include_system_membership:
-            conditions.append(f"parent_class.name <> '{ClassEnum.System.name}'")
-        if not parent_class_enum:
-            parent_class_enum = class_enum
-        if collection_enum:
-            conditions.append(
-                f"parent_class.name = '{parent_class_enum.value}' "
-                f"and collections.name = '{collection_enum.value}'"
-            )
 
-        object_placeholders = ", ".join("?" * len(object_ids))
-        conditions.append(
-            f"(child_object.object_id in ({object_placeholders}) "
-            f"OR parent_object.object_id in ({object_placeholders}))"
+        query_conditions = []
+        params = {}
+
+        # We first add conditions for looking the object.
+        query_conditions.append(
+            "(child_object.object_id = :object_id OR parent_object.object_id = :object_id)"
         )
-        if conditions:
-            query_string += " WHERE " + " AND ".join(conditions)
-        return self._db.fetchall_dict(
-            query_string, object_ids + object_ids
-        )  #  Passing obth for parent and child
+        params["object_id"] = object_id
+
+        # Query filtering
+        if exclude_system_membership:
+            query_conditions.append("parent_class.name <> :parent_class_name")
+            params["parent_class_name"] = ClassEnum.System.name
+        if collection:
+            query_conditions.append("collections.name = :collection_name")
+            params["collection_name"] = collection.name
+
+        query_string += " WHERE " + " AND ".join(query_conditions)
+
+        return self._db.fetchall_dict(query_string, params=params)
 
     def get_memberships_system(
         self,
@@ -2491,6 +2500,9 @@ class PlexosDB:
             params.append(category_id)
             query += "AND obj.category_id = ?"
         result = self._db.fetchone(query, tuple(params))
+        if not result:
+            msg = f"Object = {name} not found on the database."
+            raise NotFoundError(msg)
         assert result
         return result[0]
 
@@ -3064,7 +3076,6 @@ class PlexosDB:
         class_id = self.get_class_id(class_enum)
         query = f"SELECT name from {Schema.Objects.name} WHERE class_id = ?"
         result = self._db.query(query, (class_id,))
-        assert result
         return [d[0] for d in result]
 
     def list_parent_objects(

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1997,7 +1997,7 @@ class PlexosDB:
     ) -> list[dict[str, Any]]:
         """Retrieve all memberships for a given object.
 
-        By default it does not return the system membership.
+        By default it returns the system membership.
 
         Parameters
         ----------
@@ -2047,7 +2047,7 @@ class PlexosDB:
         """
 
         query_conditions = []
-        params = {}
+        params: dict[str, int | float | str] = {}
 
         # We first add conditions for looking the object.
         query_conditions.append(

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1620,7 +1620,7 @@ class PlexosDB:
         raise NotImplementedError
 
     def delete_object(self, class_enum: ClassEnum, /, *, name: str) -> None:
-        """Delete an object and its memberhips from the database.
+        """Delete an object and its memberships from the database.
 
         Default behaviour is to remove all the references of the object including memberships and data.
         """

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1902,7 +1902,7 @@ class PlexosDB:
         """
         result = self._db.fetchone(query, (name, class_enum))
         if not result:
-            msg = f"Category = `{name} not found on the database."
+            msg = f"Category = `{name}` not found on the database."
             raise NotFoundError(msg)
         return result[0]
 

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1424,7 +1424,6 @@ class PlexosDB:
             object_class, original_name, exclude_system_membership=True
         )
         for membership in all_memberships:
-            membership_mapping = {}
             parent_name = membership["parent_name"]
             child_name = membership["child_name"]
             parent_class = ClassEnum[membership["parent_class_name"]]

--- a/src/plexosdb/db.py
+++ b/src/plexosdb/db.py
@@ -1235,18 +1235,17 @@ class PlexosDB:
             parent_object_id = self.get_object_id(parent_class, parent_object_name)
             child_object_id = self.get_object_id(child_class, child_object_name)
             collection_id = self.get_collection_id(collection, parent_class, child_class)
-
-            query = """
-            SELECT 1 FROM t_membership
-            WHERE parent_object_id = ?
-            AND child_object_id = ?
-            AND collection_id = ?
-            """
-            result = self._db.query(query, (parent_object_id, child_object_id, collection_id))
-            return bool(result)
-
-        except AssertionError:
+        except NotFoundError:
             return False
+
+        query = """
+        SELECT 1 FROM t_membership
+        WHERE parent_object_id = ?
+        AND child_object_id = ?
+        AND collection_id = ?
+        """
+        result = self._db.query(query, (parent_object_id, child_object_id, collection_id))
+        return bool(result)
 
     def check_object_exists(self, class_enum: ClassEnum, name: str) -> bool:
         """Check if an object exists in the database.

--- a/src/plexosdb/db_manager.py
+++ b/src/plexosdb/db_manager.py
@@ -316,7 +316,7 @@ class SQLiteManager:
         query: str,
         params: tuple[Any, ...] | dict[str, Any] | None = None,
         batch_size: int = 1000,
-    ) -> Iterator:
+    ) -> Iterator[Any]:
         """Execute a read-only query and return an iterator of results.
 
         This is memory-efficient for large result sets. Use only for SELECT statements.
@@ -417,7 +417,7 @@ class SQLiteManager:
             logger.error("Database optimization failed: {}", error)
             return False
 
-    def query(self, query: str, params: tuple[Any, ...] | dict[str, Any] | None = None) -> list:
+    def query(self, query: str, params: tuple[Any, ...] | dict[str, Any] | None = None) -> list[Any]:
         """Execute a read-only query and return all results.
 
         Note: This method should ONLY be used for SELECT statements.
@@ -450,7 +450,7 @@ class SQLiteManager:
         finally:
             cursor.close()
 
-    def fetchall(self, query: str, params: tuple[Any, ...] | dict[str, Any] | None = None) -> list:
+    def fetchall(self, query: str, params: tuple[Any, ...] | dict[str, Any] | None = None) -> list[Any]:
         """Execute a query and return all results as a list of rows.
 
         This method is a standard DB-API style alias for query().
@@ -539,7 +539,7 @@ class SQLiteManager:
 
     def fetchmany(
         self, query: str, size: int = 1000, params: tuple[Any, ...] | dict[str, Any] | None = None
-    ) -> list:
+    ) -> list[Any]:
         """Execute a query and return a specified number of rows.
 
         Parameters

--- a/src/plexosdb/schema.sql
+++ b/src/plexosdb/schema.sql
@@ -307,6 +307,8 @@ CREATE TABLE `t_membership`
     UNIQUE(`parent_object_id`, `collection_id`, `child_object_id`)
     CONSTRAINT PK_t_membership
                PRIMARY KEY (`membership_id`)
+    FOREIGN KEY (`parent_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
+    FOREIGN KEY (`child_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
 );
 
 
@@ -338,8 +340,8 @@ CREATE TABLE `t_data`
     `value` FLOAT NULL,
     `state` INT NULL,
     `uid` BIGINT NULL,
-    CONSTRAINT PK_t_data
-               PRIMARY KEY (`data_id`)
+    CONSTRAINT PK_t_data PRIMARY KEY (`data_id`)
+    FOREIGN KEY (`membership_id`) REFERENCES `t_membership`(`membership_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_date_from`

--- a/src/plexosdb/schema.sql
+++ b/src/plexosdb/schema.sql
@@ -62,9 +62,15 @@ CREATE TABLE `t_message`
 (
     `number` INT NOT NULL,
     `severity` INT NULL,
-    `default_action` INT NULL, `action` INT NULL, `description` VARCHAR(512) NULL,
+    `default_action` INT NULL,
+    `action` INT NULL,
+    `description` VARCHAR(512) NULL,
     CONSTRAINT PK_t_message
-               PRIMARY KEY (`number`)
+               PRIMARY KEY (`number`),
+    CONSTRAINT FK_t_message_default_action
+               FOREIGN KEY (`default_action`) REFERENCES `t_action`(`action_id`),
+    CONSTRAINT FK_t_message_action
+               FOREIGN KEY (`action`) REFERENCES `t_action`(`action_id`)
 );
 
 CREATE TABLE `t_property_tag`
@@ -79,11 +85,12 @@ CREATE TABLE `t_custom_rule`
 (
     `number` INT AUTO_INCREMENT NOT NULL,
     `condition` VARCHAR(512) NULL,
-
     `action_id` INT NULL,
     `message` VARCHAR(512) NULL,
     CONSTRAINT PK_t_custom_rule
-               PRIMARY KEY (`number`)
+               PRIMARY KEY (`number`),
+    CONSTRAINT FK_t_custom_rule_action
+               FOREIGN KEY (`action_id`) REFERENCES `t_action`(`action_id`)
 );
 
 CREATE TABLE `t_class`
@@ -97,7 +104,11 @@ CREATE TABLE `t_class`
     `state` INT NULL,
     `inherits_from` INT NULL,
     CONSTRAINT PK_t_class
-               PRIMARY KEY (`class_id`)
+               PRIMARY KEY (`class_id`),
+    CONSTRAINT FK_t_class_group
+               FOREIGN KEY (`class_group_id`) REFERENCES `t_class_group`(`class_group_id`),
+    CONSTRAINT FK_t_class_inherits
+               FOREIGN KEY (`inherits_from`) REFERENCES `t_class`(`class_id`)
 );
 
 CREATE TABLE `t_collection`
@@ -118,7 +129,11 @@ CREATE TABLE `t_collection`
     `complement_description` VARCHAR(255) NULL,
     `rank` INT NULL,
     CONSTRAINT PK_t_collection
-               PRIMARY KEY (`collection_id`)
+               PRIMARY KEY (`collection_id`),
+    CONSTRAINT FK_t_collection_parent_class
+               FOREIGN KEY (`parent_class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_collection_child_class
+               FOREIGN KEY (`child_class_id`) REFERENCES `t_class`(`class_id`)
 );
 
 CREATE TABLE `t_collection_report`
@@ -130,7 +145,17 @@ CREATE TABLE `t_collection_report`
     `rule_right_collection_id` INT NULL,
     `rule_id` INT NULL,
     CONSTRAINT PK_t_collection_report
-               PRIMARY KEY (`collection_id`, `left_collection_id`, `right_collection_id`)
+               PRIMARY KEY (`collection_id`, `left_collection_id`, `right_collection_id`),
+    CONSTRAINT FK_t_collection_report_collection
+               FOREIGN KEY (`collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_collection_report_left
+               FOREIGN KEY (`left_collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_collection_report_right
+               FOREIGN KEY (`right_collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_collection_report_rule_left
+               FOREIGN KEY (`rule_left_collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_collection_report_rule_right
+               FOREIGN KEY (`rule_right_collection_id`) REFERENCES `t_collection`(`collection_id`)
 );
 
 CREATE TABLE `t_property`
@@ -158,7 +183,13 @@ CREATE TABLE `t_property`
     `tag` VARCHAR(512) NULL,
     `is_visible` BIT NULL,
     CONSTRAINT PK_t_property
-               PRIMARY KEY (`property_id`)
+               PRIMARY KEY (`property_id`),
+    CONSTRAINT FK_t_property_collection
+               FOREIGN KEY (`collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_property_group
+               FOREIGN KEY (`property_group_id`) REFERENCES `t_property_group`(`property_group_id`),
+    CONSTRAINT FK_t_property_unit
+               FOREIGN KEY (`unit_id`) REFERENCES `t_unit`(`unit_id`)
 );
 
 CREATE TABLE `t_property_report`
@@ -184,7 +215,15 @@ CREATE TABLE `t_property_report`
     `description` VARCHAR(255) NULL,
     `is_visible` BIT NULL,
     CONSTRAINT PK_t_property_report
-               PRIMARY KEY (`property_id`)
+               PRIMARY KEY (`property_id`),
+    CONSTRAINT FK_t_property_report_collection
+               FOREIGN KEY (`collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_property_report_group
+               FOREIGN KEY (`property_group_id`) REFERENCES `t_property_group`(`property_group_id`),
+    CONSTRAINT FK_t_property_report_unit
+               FOREIGN KEY (`unit_id`) REFERENCES `t_unit`(`unit_id`),
+    CONSTRAINT FK_t_property_report_summary_unit
+               FOREIGN KEY (`summary_unit_id`) REFERENCES `t_unit`(`unit_id`)
 );
 
 CREATE TABLE `t_custom_column`
@@ -195,7 +234,9 @@ CREATE TABLE `t_custom_column`
     `position` INT NULL,
     `GUID` CHAR(36) NULL,
     CONSTRAINT PK_t_custom_column
-               PRIMARY KEY (`column_id`)
+               PRIMARY KEY (`column_id`),
+    CONSTRAINT FK_t_custom_column_class
+               FOREIGN KEY (`class_id`) REFERENCES `t_class`(`class_id`)
 );
 
 CREATE TABLE `t_attribute`
@@ -215,7 +256,11 @@ CREATE TABLE `t_attribute`
     `tag` VARCHAR(512) NULL,
     `is_visible` BIT NULL,
     CONSTRAINT PK_t_attribute
-               PRIMARY KEY (`attribute_id`)
+               PRIMARY KEY (`attribute_id`),
+    CONSTRAINT FK_t_attribute_class
+               FOREIGN KEY (`class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_attribute_unit
+               FOREIGN KEY (`unit_id`) REFERENCES `t_unit`(`unit_id`)
 );
 
 CREATE TABLE `t_category`
@@ -225,9 +270,11 @@ CREATE TABLE `t_category`
     `rank` INT NOT NULL,
     `name` VARCHAR(512) NULL,
     `state` INT NULL,
-    UNIQUE (`class_id`, `name`)
+    UNIQUE (`class_id`, `name`),
     CONSTRAINT PK_t_category
-               PRIMARY KEY (`category_id`)
+               PRIMARY KEY (`category_id`),
+    CONSTRAINT FK_t_category_class
+               FOREIGN KEY (`class_id`) REFERENCES `t_class`(`class_id`)
 );
 
 CREATE TABLE `t_object`
@@ -242,12 +289,14 @@ CREATE TABLE `t_object`
     `X` INT NULL,
     `Y` INT NULL,
     `Z` INT NULL,
-    UNIQUE (`class_id`, `name`)
+    UNIQUE (`class_id`, `name`),
     CONSTRAINT PK_t_object
-               PRIMARY KEY (`object_id`)
+               PRIMARY KEY (`object_id`),
+    CONSTRAINT FK_t_object_class
+               FOREIGN KEY (`class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_object_category
+               FOREIGN KEY (`category_id`) REFERENCES `t_category`(`category_id`)
 );
-
-
 
 CREATE TABLE `t_memo_object`
 (
@@ -256,7 +305,11 @@ CREATE TABLE `t_memo_object`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_memo_object
-               PRIMARY KEY (`object_id`, `column_id`)
+               PRIMARY KEY (`object_id`, `column_id`),
+    CONSTRAINT FK_t_memo_object_object
+               FOREIGN KEY (`object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_memo_object_column
+               FOREIGN KEY (`column_id`) REFERENCES `t_custom_column`(`column_id`)
 );
 
 CREATE TABLE `t_report`
@@ -271,7 +324,11 @@ CREATE TABLE `t_report`
     `write_flat_files` BIT NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_report
-               PRIMARY KEY (`object_id`, `property_id`, `phase_id`)
+               PRIMARY KEY (`object_id`, `property_id`, `phase_id`),
+    CONSTRAINT FK_t_report_object
+               FOREIGN KEY (`object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_report_property
+               FOREIGN KEY (`property_id`) REFERENCES `t_property_report`(`property_id`)
 );
 
 CREATE TABLE `t_object_meta`
@@ -282,7 +339,9 @@ CREATE TABLE `t_object_meta`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_object_meta
-               PRIMARY KEY (`object_id`, `class`, `property`)
+               PRIMARY KEY (`object_id`, `class`, `property`),
+    CONSTRAINT FK_t_object_meta_object
+               FOREIGN KEY (`object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_attribute_data`
@@ -292,7 +351,11 @@ CREATE TABLE `t_attribute_data`
     `value` FLOAT NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_attribute_data
-               PRIMARY KEY (`object_id`, `attribute_id`)
+               PRIMARY KEY (`object_id`, `attribute_id`),
+    CONSTRAINT FK_t_attribute_data_object
+               FOREIGN KEY (`object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_attribute_data_attribute
+               FOREIGN KEY (`attribute_id`) REFERENCES `t_attribute`(`attribute_id`)
 );
 
 CREATE TABLE `t_membership`
@@ -304,13 +367,20 @@ CREATE TABLE `t_membership`
     `child_class_id` INT NULL,
     `child_object_id` INT NULL,
     `state` INT NULL,
-    UNIQUE(`parent_object_id`, `collection_id`, `child_object_id`)
+    UNIQUE(`parent_object_id`, `collection_id`, `child_object_id`),
     CONSTRAINT PK_t_membership
-               PRIMARY KEY (`membership_id`)
-    FOREIGN KEY (`parent_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
-    FOREIGN KEY (`child_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
+               PRIMARY KEY (`membership_id`),
+    CONSTRAINT FK_t_membership_parent_class
+               FOREIGN KEY (`parent_class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_membership_parent_object
+               FOREIGN KEY (`parent_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_membership_collection
+               FOREIGN KEY (`collection_id`) REFERENCES `t_collection`(`collection_id`),
+    CONSTRAINT FK_t_membership_child_class
+               FOREIGN KEY (`child_class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_membership_child_object
+               FOREIGN KEY (`child_object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE
 );
-
 
 CREATE TABLE `t_memo_membership`
 (
@@ -318,7 +388,9 @@ CREATE TABLE `t_memo_membership`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_memo_membership
-               PRIMARY KEY (`membership_id`)
+               PRIMARY KEY (`membership_id`),
+    CONSTRAINT FK_t_memo_membership_membership
+               FOREIGN KEY (`membership_id`) REFERENCES `t_membership`(`membership_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_membership_meta`
@@ -329,7 +401,9 @@ CREATE TABLE `t_membership_meta`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_membership_meta
-               PRIMARY KEY (`membership_id`, `class`, `property`)
+               PRIMARY KEY (`membership_id`, `class`, `property`),
+    CONSTRAINT FK_t_membership_meta_membership
+               FOREIGN KEY (`membership_id`) REFERENCES `t_membership`(`membership_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_data`
@@ -340,8 +414,12 @@ CREATE TABLE `t_data`
     `value` FLOAT NULL,
     `state` INT NULL,
     `uid` BIGINT NULL,
-    CONSTRAINT PK_t_data PRIMARY KEY (`data_id`)
-    FOREIGN KEY (`membership_id`) REFERENCES `t_membership`(`membership_id`) ON DELETE CASCADE
+    CONSTRAINT PK_t_data
+               PRIMARY KEY (`data_id`),
+    CONSTRAINT FK_t_data_membership
+               FOREIGN KEY (`membership_id`) REFERENCES `t_membership`(`membership_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_data_property
+               FOREIGN KEY (`property_id`) REFERENCES `t_property`(`property_id`)
 );
 
 CREATE TABLE `t_date_from`
@@ -350,7 +428,9 @@ CREATE TABLE `t_date_from`
     `date` DATETIME NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_date_from
-               PRIMARY KEY (`data_id`)
+               PRIMARY KEY (`data_id`),
+    CONSTRAINT FK_t_date_from_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_date_to`
@@ -359,7 +439,9 @@ CREATE TABLE `t_date_to`
     `date` DATETIME NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_date_to
-               PRIMARY KEY (`data_id`)
+               PRIMARY KEY (`data_id`),
+    CONSTRAINT FK_t_date_to_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_tag`
@@ -369,7 +451,13 @@ CREATE TABLE `t_tag`
     `state` INT NULL,
     `action_id` INT NULL,
     CONSTRAINT PK_t_tag
-               PRIMARY KEY (`data_id`, `object_id`)
+               PRIMARY KEY (`data_id`, `object_id`),
+    CONSTRAINT FK_t_tag_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_tag_object
+               FOREIGN KEY (`object_id`) REFERENCES `t_object`(`object_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_tag_action
+               FOREIGN KEY (`action_id`) REFERENCES `t_action`(`action_id`)
 );
 
 CREATE TABLE `t_text`
@@ -380,7 +468,13 @@ CREATE TABLE `t_text`
     `state` INT NULL,
     `action_id` INT NULL,
     CONSTRAINT PK_t_text
-               PRIMARY KEY (`data_id`, `class_id`)
+               PRIMARY KEY (`data_id`, `class_id`),
+    CONSTRAINT FK_t_text_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE,
+    CONSTRAINT FK_t_text_class
+               FOREIGN KEY (`class_id`) REFERENCES `t_class`(`class_id`),
+    CONSTRAINT FK_t_text_action
+               FOREIGN KEY (`action_id`) REFERENCES `t_action`(`action_id`)
 );
 
 CREATE TABLE `t_memo_data`
@@ -389,7 +483,9 @@ CREATE TABLE `t_memo_data`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_memo_data
-               PRIMARY KEY (`data_id`)
+               PRIMARY KEY (`data_id`),
+    CONSTRAINT FK_t_memo_data_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_data_meta`
@@ -400,7 +496,9 @@ CREATE TABLE `t_data_meta`
     `value` VARCHAR(512) NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_data_meta
-               PRIMARY KEY (`data_id`, `class`, `property`)
+               PRIMARY KEY (`data_id`, `class`, `property`),
+    CONSTRAINT FK_t_data_meta_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE
 );
 
 CREATE TABLE `t_band`
@@ -409,5 +507,7 @@ CREATE TABLE `t_band`
     `band_id` INT NULL,
     `state` INT NULL,
     CONSTRAINT PK_t_band
-               PRIMARY KEY (`data_id`)
+               PRIMARY KEY (`data_id`),
+    CONSTRAINT FK_t_band_data
+               FOREIGN KEY (`data_id`) REFERENCES `t_data`(`data_id`) ON DELETE CASCADE
 );

--- a/tests/test_plexosdb.py
+++ b/tests/test_plexosdb.py
@@ -424,12 +424,12 @@ def test_list_child_objects(db_instance_with_schema):
     assert len(children_collection) == 1
 
     # Test with non-existent parent
-    children_none = db.list_child_objects("NonExistentGen", parent_class=ClassEnum.Generator)
-    assert len(children_none) == 0
+    with pytest.raises(NotFoundError):
+        _ = db.list_child_objects("NonExistentGen", parent_class=ClassEnum.Generator)
 
 
 @pytest.mark.listing
-def test_list_parent_objects(db_instance_with_schema):
+def test_list_parent_objects(db_instance_with_schema: PlexosDB):
     db = db_instance_with_schema
 
     # Use classes that are known to exist in the test schema
@@ -489,8 +489,8 @@ def test_list_parent_objects(db_instance_with_schema):
     assert len(parents_collection) == 2
 
     # Test with non-existent child
-    parents_none = db.list_parent_objects("NonExistentNode", child_class=ClassEnum.Node)
-    assert len(parents_none) == 0
+    with pytest.raises(NotFoundError):
+        _ = db.list_parent_objects("NonExistentNode", child_class=ClassEnum.Node)
 
     # Test check_membership_exists with non-existent objects
     membership_with_no_parent = db.check_membership_exists(

--- a/tests/test_plexosdb_delete_object.py
+++ b/tests/test_plexosdb_delete_object.py
@@ -2,7 +2,7 @@ import pytest
 
 from plexosdb.db import PlexosDB
 from plexosdb.enums import ClassEnum
-from plexosdb.exceptions import NoPropertiesError, NotFoundError
+from plexosdb.exceptions import NameError, NoPropertiesError, NotFoundError
 
 
 def test_delete_object_with_no_properties(db_instance_with_schema: PlexosDB, caplog):
@@ -54,5 +54,158 @@ def test_delete_object_with_properties(db_instance_with_schema, caplog):
         assert not db.get_object_properties(object_class, object_name)
 
 
-def test_delete_properties(db_instance_with_schema: PlexosDB):
-    pass
+def test_delete_property_basic(db_instance_with_schema: PlexosDB):
+    """Test basic property deletion functionality."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+    property_value = 100.0
+
+    # Setup: Add object and property
+    db.add_object(object_class, object_name)
+    db.add_property(object_class, object_name, property_name, property_value)
+
+    # Verify property exists
+    properties = db.get_object_properties(object_class, object_name)
+    assert len(properties) == 1
+    assert properties[0]["property"] == property_name
+    assert properties[0]["value"] == property_value
+
+    # Delete the property
+    db.delete_property(object_class, object_name, property_name=property_name)
+
+    # Verify property is deleted
+    with pytest.raises(NoPropertiesError):
+        db.get_object_properties(object_class, object_name)
+
+
+def test_delete_property_with_scenario(db_instance_with_schema: PlexosDB):
+    """Test deleting a property associated with a specific scenario."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+    scenario_name = "High Demand"
+
+    # Setup: Add object and properties with and without scenario
+    db.add_object(object_class, object_name)
+    db.add_property(object_class, object_name, property_name, 100.0)  # No scenario
+    db.add_property(object_class, object_name, property_name, 200.0, scenario=scenario_name)  # With scenario
+
+    # Verify both properties exist
+    properties = db.get_object_properties(object_class, object_name)
+    assert len(properties) == 2
+
+    # Delete only the property with the scenario
+    db.delete_property(object_class, object_name, property_name=property_name, scenario=scenario_name)
+
+    # Verify only the property without scenario remains
+    properties = db.get_object_properties(object_class, object_name)
+    assert len(properties) == 1
+    assert properties[0]["value"] == 100.0
+    assert properties[0]["scenario"] is None
+
+
+def test_delete_property_nonexistent_object(db_instance_with_schema: PlexosDB):
+    """Test that deleting a property from a nonexistent object raises NotFoundError."""
+    db = db_instance_with_schema
+
+    with pytest.raises(NotFoundError, match="Object = `NonexistentGen` does not exist"):
+        db.delete_property(ClassEnum.Generator, "NonexistentGen", property_name="Max Capacity")
+
+
+def test_delete_property_invalid_property_name(db_instance_with_schema: PlexosDB):
+    """Test that deleting an invalid property name raises NameError."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+
+    # Setup: Add object
+    db.add_object(object_class, object_name)
+
+    with pytest.raises(NameError, match="Property 'Invalid Property' does not exist for collection"):
+        db.delete_property(object_class, object_name, property_name="Invalid Property")
+
+
+def test_delete_property_nonexistent_property(db_instance_with_schema: PlexosDB):
+    """Test that deleting a property that doesn't exist for the object raises NotFoundError."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+
+    # Setup: Add object but no properties
+    db.add_object(object_class, object_name)
+
+    with pytest.raises(
+        NotFoundError, match=f"Property '{property_name}' not found for object '{object_name}'"
+    ):
+        db.delete_property(object_class, object_name, property_name=property_name)
+
+
+def test_delete_property_nonexistent_scenario(db_instance_with_schema: PlexosDB):
+    """Test that deleting a property with nonexistent scenario raises NotFoundError."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+
+    # Setup: Add object and property
+    db.add_object(object_class, object_name)
+    db.add_property(object_class, object_name, property_name, 100.0)
+
+    with pytest.raises(NotFoundError, match="Scenario 'Nonexistent Scenario' does not exist"):
+        db.delete_property(
+            object_class, object_name, property_name=property_name, scenario="Nonexistent Scenario"
+        )
+
+
+def test_delete_property_scenario_not_associated(db_instance_with_schema: PlexosDB):
+    """Test that deleting a property with a scenario that's not associated raises NotFoundError."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+    scenario_name = "High Demand"
+    other_scenario = "Low Demand"
+
+    # Setup: Add object, property, and scenarios
+    db.add_object(object_class, object_name)
+    db.add_property(object_class, object_name, property_name, 100.0, scenario=scenario_name)
+    db.add_scenario(other_scenario)  # Add scenario but don't associate with property
+
+    with pytest.raises(
+        NotFoundError, match=f"Property '{property_name}' with scenario '{other_scenario}' not found"
+    ):
+        db.delete_property(object_class, object_name, property_name=property_name, scenario=other_scenario)
+
+
+def test_delete_property_with_related_data(db_instance_with_schema: PlexosDB):
+    """Test that deleting a property also removes related data (text, tags, dates) due to cascade."""
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    property_name = "Max Capacity"
+    scenario_name = "High Demand"
+
+    # Setup: Add object and property with text and scenario
+    db.add_object(object_class, object_name)
+    text_data = {ClassEnum.Generator: "Some text description"}
+    db.add_property(object_class, object_name, property_name, 100.0, scenario=scenario_name, text=text_data)
+
+    # Verify property exists with related data
+    properties = db.get_object_properties(object_class, object_name)
+    assert len(properties) == 1
+    assert properties[0]["scenario"] == scenario_name
+    assert len(properties[0]["texts"]) > 0
+
+    # Delete the property
+    db.delete_property(object_class, object_name, property_name=property_name)
+
+    # Verify property and related data are deleted
+    with pytest.raises(NoPropertiesError):
+        db.get_object_properties(object_class, object_name)
+
+    # The scenario object should still exist (it's not deleted when property is deleted)
+    assert db.check_scenario_exists(scenario_name)

--- a/tests/test_plexosdb_delete_object.py
+++ b/tests/test_plexosdb_delete_object.py
@@ -29,7 +29,7 @@ def test_delete_object_with_no_properties(db_instance_with_schema: PlexosDB, cap
     with pytest.raises(NotFoundError):
         db.list_object_memberships(object_class, object_name)
 
-    # Checck there is no object_id
+    # Check there is no object_id
     with pytest.raises(NotFoundError):
         _ = db.get_object_id(object_class, object_name)
 

--- a/tests/test_plexosdb_delete_object.py
+++ b/tests/test_plexosdb_delete_object.py
@@ -1,0 +1,54 @@
+import pytest
+
+from plexosdb.db import PlexosDB
+from plexosdb.enums import ClassEnum
+from plexosdb.exceptions import NoPropertiesError, NotFoundError
+
+
+def test_delete_object_with_no_properties(db_instance_with_schema: PlexosDB, caplog):
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    _ = db.add_object(object_class, object_name)
+
+    another_object = "TestGen2"
+    _ = db.add_object(object_class, another_object)
+
+    assert len(db.list_objects_by_class(object_class)) == 2
+
+    assert len(db.list_object_memberships(object_class, object_name)) == 1
+
+    db.delete_object(object_class, name=object_name)
+
+    # Assert object does not appear on the list of names
+    assert not db.check_object_exists(object_class, name=object_name)
+    assert object_name not in db.list_objects_by_class(object_class)
+    assert len(db.list_objects_by_class(object_class)) == 1
+
+    # Check that we removed all the memberships
+    with pytest.raises(NotFoundError):
+        db.list_object_memberships(object_class, object_name)
+
+    # Checck there is no object_id
+    with pytest.raises(NotFoundError):
+        _ = db.get_object_id(object_class, object_name)
+
+
+def test_delete_object_with_properties(db_instance_with_schema, caplog):
+    db = db_instance_with_schema
+    object_name = "TestGen"
+    object_class = ClassEnum.Generator
+    test_property_name = "Max Capacity"
+    test_property_value = 100.0
+    _ = db.add_object(object_class, object_name)
+    _ = db.add_property(
+        object_class,
+        object_name,
+        test_property_name,
+        test_property_value,
+    )
+
+    # Test default behaviour of copying properties
+    db.delete_object(object_class, name=object_name)
+    with pytest.raises(NoPropertiesError):
+        assert not db.get_object_properties(object_class, object_name)

--- a/tests/test_plexosdb_delete_object.py
+++ b/tests/test_plexosdb_delete_object.py
@@ -52,3 +52,7 @@ def test_delete_object_with_properties(db_instance_with_schema, caplog):
     db.delete_object(object_class, name=object_name)
     with pytest.raises(NoPropertiesError):
         assert not db.get_object_properties(object_class, object_name)
+
+
+def test_delete_properties(db_instance_with_schema: PlexosDB):
+    pass

--- a/tests/test_plexosdb_from_records.py
+++ b/tests/test_plexosdb_from_records.py
@@ -32,8 +32,8 @@ def test_bulk_insert_properties_from_records(db_instance_with_schema):
     assert properties[0]["scenario"] == "Base Case"
 
 
-def test_bulk_insert_memberships_from_records(db_instance_with_schema):
-    db: PlexosDB = db_instance_with_schema
+def test_bulk_insert_memberships_from_records(db_instance_with_schema: PlexosDB):
+    db = db_instance_with_schema
 
     # Create the objects first
     objects = list(f"Generator_{i}" for i in range(5))
@@ -66,13 +66,12 @@ def test_bulk_insert_memberships_from_records(db_instance_with_schema):
     ]
     db.add_memberships_from_records(memberships)
 
-    db_memberships = db.get_object_memberships(
-        objects,
-        class_enum=ClassEnum.Node,
-        parent_class_enum=ClassEnum.Generator,
-        collection_enum=CollectionEnum.Nodes,
+    db_memberships = db.list_object_memberships(
+        ClassEnum.Node,
+        objects[0],
+        collection=CollectionEnum.Nodes,
     )
-    assert len(db_memberships) == 5
+    assert len(db_memberships) == 2  # 1 + system membership
 
     memberships = [
         {


### PR DESCRIPTION
List of changes
    - Renamed `list_memberhips` to `list_object_memberships`
    - Simplified the `list_object_memberships` to just list an object at a time
    - Changed the argument order for `list_object_memberships` to follow convention of `ClassEnum` first.
    - Added foreign key constraints on `schema.sql` to simplify delete.
    - Added docs on how to use delete objects.
    - Added testing for new function